### PR TITLE
[CCA-1] Adds configuration properties files for rv-cc-test-jg.

### DIFF
--- a/configurations/firefox.properties
+++ b/configurations/firefox.properties
@@ -1,0 +1,6 @@
+webdriver = firefox
+
+# This needs to point to the GeckoDriver executable on your system.
+# Currently, you need to download it, remember where you downloaded
+# it, and update this path to the location where you downloaded it.
+webdriver.gecko.driver = /home/misspellted/geckodriver

--- a/configurations/html-js.properties
+++ b/configurations/html-js.properties
@@ -1,0 +1,1 @@
+webdriver = html-js

--- a/configurations/html.properties
+++ b/configurations/html.properties
@@ -1,0 +1,1 @@
+webdriver=html


### PR DESCRIPTION
These properties files contain the identifiers of their respective Selenium WebDriver
and, in the case of the firefox.properties file, addition configuration details, like
the webdriver.gecko.driver property value required at the System properties level.